### PR TITLE
Wrap dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/zambezi/grid-components.git"
   },
   "devDependencies": {
-    "@zambezi/grid": "^0.8.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-es2015-rollup": "1.1.1",
     "babel-register": "6.9.0",
@@ -38,6 +37,7 @@
     "rollup-plugin-postcss": "0.1.1"
   },
   "dependencies": {
+    "@zambezi/grid": "^0.9.0",
     "@zambezi/d3-utils": "^3.2.0",
     "d3-dispatch": "^1.0.1",
     "d3-selection": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid-components",
-  "version": "0.2.0",
+  "version": "0.3.0-wrap-dependency-fix.1",
   "description": "Components for the Zambezi Grids",
   "keywords": [
     "d3",


### PR DESCRIPTION
## Description

The @zambezi/grid is now a proper dependecy of the grid components project.
It exposes row wrapping, which is now used from the cell-selection component.

## Motivation and Context

Without this change cell selection will not fully work.
The selection gesture will crash the grid with an undefined pointer error.

## How Was This Tested?

This is tested on the cell-selection example in the the `examples` folder.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
