### PR TITLE
Expose edit cell

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,3 +11,4 @@
 
 - Column specific components
   - [Edit cell value](man/edit-cell-value.md)
+  - [Bespoke cell editors](man/bespoke-cell-editors.md)

--- a/examples/create-custom-editors.html
+++ b/examples/create-custom-editors.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+
+<style>
+.external-editor {
+  display: none;
+}
+
+.external-editor.is-editing {
+  display: block;
+}
+
+.external-editor.is-invalid {
+  background-color: red;
+  color: white;
+}
+
+.external-editor-placeholder {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 2px;
+  background-color: magenta;
+  color: white;
+}
+
+</style>
+
+<h1>Creating  custom cell editors</h1>
+
+<p>Edit cells on the <code>username</code> column with a bespoke editor.</p>
+
+<div class="grid-target"></div>
+
+<section class="external-editor">
+  <h2 class="title">some custom external editor</h2>
+  <p>
+    <input type="text" id="username" placeholder="ok"></input>
+  </p>
+</section>
+
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/d3-selection/build/d3-selection.js"></script>
+<script src="../node_modules/d3-dispatch/build/d3-dispatch.js"></script>
+<script src="../node_modules/d3-ease/build/d3-ease.js"></script>
+<script src="../node_modules/d3-format/build/d3-format.js"></script>
+<script src="../node_modules/d3-array/build/d3-array.js"></script>
+<script src="../node_modules/d3-transition/build/d3-transition.js"></script>
+<script src="../node_modules/d3-timer/build/d3-timer.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/grid/dist/grid.js"></script>
+<script src="../dist/grid-components.js"></script>
+<script>
+
+  var table = grid.createGrid()
+          .columns(
+            [
+              { key: 'name', locked: 'left', width: 200 }
+            , {
+                key: 'username'
+              , components: [
+                  gridComponents.createEditCell()
+                      .component(createExternalEditor())
+                      .on('change', onUsernameChange)
+                      .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                      .validate(validateUserName)
+                      .editable(isNotZack)
+
+                , grid.updateTextIfChanged
+                ]
+              }
+            , { key: 'email', sortDescending: true }
+            , { key: 'phone' }
+            ]
+          )
+    , rows = _.range(1, 2000).map(faker.Helpers.createCard)
+
+  d3.select('.grid-target')
+      .style('height', '300px')
+      .datum(rows)
+      .call(table)
+
+  function onUsernameChange(row, value) {
+    row.username = value.toUpperCase()
+  }
+
+  function validateUserName(row, value) {
+    if (!value) return 'Username cannot be empty'
+    if (!value.split('').some(isDifferentCharacter())) return 'Cannot all be the same character'
+  }
+
+  function isDifferentCharacter() {
+    let found
+    return function check(ch) {
+      if (found && !~found.indexOf(ch)) return true
+      found = ch
+      return false
+    }
+  }
+
+  function onUsernameChange(row, value) {
+    row.username = value.toUpperCase()
+  }
+
+  function validateUserName(row, value) {
+    if (!value) return 'Username cannot be empty'
+    if (!value.split('').some(isDifferentCharacter())) return 'Cannot all be the same character'
+  }
+
+  function isNotZack(cell) {
+    return cell.row.username.indexOf('Zac') !== 0
+  }
+
+
+
+  // On some other module somewhere, something like this is defined,
+
+  function createExternalEditor() {
+
+    const dispatch = d3.dispatch('partialedit', 'commit', 'cancel')
+        , api = d3Utils.rebind().from(dispatch, 'on')
+
+    function externalEditor(s) {
+      s.each(externalEditorEach)
+    }
+
+    return api(externalEditor)
+
+    function externalEditorEach(d, i) {
+
+      console.debug('externalEditorEach', d, i)
+
+      const target = d3.select(this).text('EDITING EXTERNALLY')
+                .classed('external-editor-placeholder', true)
+          , { column, row, isValidInput } = d
+
+          , form = d3.select('.external-editor')
+                .datum(d)
+                .classed('is-editing', true)
+                .classed('is-invalid', !isValidInput)
+
+          , title = form.select('.title')
+                .text(`edit ${column.id} currently «${column.value(row)}»`)
+          , input = form.select('[type=text]')
+                .property('value', d.tempInput || column.format(column.value(row)))
+                .on('input', onInput)
+                .on('change', commit)
+                .on('blur', commit)
+                .each(focus)
+
+      function onInput(d, i) {
+        dispatch.call('partialedit', this, d)
+      }
+
+      function focus() {
+        this.focus()
+      }
+
+      function commit() {
+        dispatch.call('commit', this, d)
+        form.classed('is-editing', false)
+      }
+    }
+  }
+
+</script>
+</body>

--- a/man/bespoke-cell-editors.md
+++ b/man/bespoke-cell-editors.md
@@ -1,0 +1,25 @@
+## bespoke cell editors
+
+You can create your own bespoke cell editors with the low-level `edit cell` component wrapper.
+The provided [edit cell value] component, for example, uses the `edit cell` component under the hood.
+
+This component provides the basic infrastructure for generic cell editors -- it will
+
+* expose a `editable` function to determine which of the cells in the column are editable.
+* detect a configurable edit gesture, upon which it will call your provided component with access to associated cell DOM element and data.  This allows you to create whatever representation you need either inline, on the grid, or outside (on a pop-up, for example)
+* run validation routines as determined by the client.
+* dispatch `change` and `validation` events depending on the results of validating the input.
+
+To use the `edit cell` component, create an instance by using the `createEditCell` factory.
+Then pass it your own editor component using the `component` getter/setter.
+
+Your component should 
+
+* be a [standard D3 component](https://bost.ocks.org/mike/chart/) that will be run on a D3 selection of the editing cell.
+* expose the `on` method of a D3 dispatcher. 
+* dispatch `partialedit` whenever the user is editing the field. This will allow the component to cache a version of the partial data so that if a cell is destroyed and reconstructed (by scrolling, for example) the component can reconstruct it's partial state.  The DOM node `value` property should have the edit value.
+* dispatch `commit` when the component determines that the edit is complete (for example, by blurring on a text input or clicking on a date picker button).  The DOM node `value` property should have the edit value.
+* dispatch `cancel` when the component determines that editing is canceled.
+* use the provided `tempInput` value, if present, to reconstruct the partial edit state.
+
+Please see the `examples/create-custom-editors.html` for an implementation example.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid-components",
-  "version": "0.3.0",
+  "version": "0.4.0-expose-base-edit.1",
   "description": "Components for the Zambezi Grids",
   "keywords": [
     "d3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { createCellSelection } from './cell-selection'
+export { createEditCell } from './edit-cell'
 export { createEditCellValue } from './edit-cell-value'


### PR DESCRIPTION
## Description

The underlying `edit cell` component -- which is used for `edit cell value` is exposed in this PR so that bespoke editors can be made by clients.

## Motivation and Context

Often, non-generic custom editors are required for the grid.  By exposing the basic component, many of the common things (validation, gesture capture, etc) can be reused.

Please check the proposed [docs](https://github.com/zambezi/grid-components/blob/expose-edit-cell/man/bespoke-cell-editors.md) and a [running example](http://bl.ocks.org/gabrielmontagne/b9d50dcf06f6a82e5b5e1a280e88ea8b).

An example has also been included with the source.

## How Was This Tested?

It was tested on the provided rig and the live exampled linked above.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
