### PR TITLE
Fix `rollup --watch` not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch": "rollup -c -w",
     "test": "mocha",
     "pretest": "npm run clean && npm run build",
-    "prepublish": "npm test"
+    "prepublish": "npm test",
+    "start": "npm run watch"
   },
   "license": "MIT",
   "main": "dist/grid-components.js",
@@ -32,9 +33,10 @@
     "mocha": "2.5.3",
     "normalize.css": "4.2.0",
     "rimraf": "2.5.3",
-    "rollup": "0.26.3",
+    "rollup": "0.34.10",
     "rollup-plugin-babel": "2.3.9",
-    "rollup-plugin-postcss": "0.1.1"
+    "rollup-plugin-postcss": "0.1.1",
+    "rollup-watch": "^2.5.0"
   },
   "dependencies": {
     "@zambezi/grid": "^0.9.0",


### PR DESCRIPTION
This PR updates  `package.json` to user newer versions of rollup, as well as adding an extra dev dependency on `rollup-watch` and a new npm script `npm start`

## Motivation and Context

I found `npm run watch` was compiling the project and then exiting without watching for changes.

## How Was This Tested?

Running the npm scripts again and verifying it behaves as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

(cherry picked from commit b12f60cf132e4a24123e824e8cdaef253e258424)