### PR TITLE
Add `editstart`  and `editend`  events for cell editors.

### DIFF
--- a/examples/create-custom-editors.html
+++ b/examples/create-custom-editors.html
@@ -70,6 +70,8 @@
                       .component(createExternalEditor())
                       .on('change', onUsernameChange)
                       .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                      .on('editstart', d => console.log('edit start', d))
+                      .on('editend', d => console.log('edit end', d))
                       .validate(validateUserName)
                       .editable(isNotZack)
 

--- a/examples/edit-cells.html
+++ b/examples/edit-cells.html
@@ -45,6 +45,8 @@
                   gridComponents.createEditCellValue()
                       .on('change', onUsernameChange)
                       .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                      .on('editstart', d => console.debug('edit start',  d))
+                      .on('editend', d => console.debug('edit end', d))
                       .characterClass('A-Za-z0-5')
                       .validate(validateUserName)
                       .editable(isNotZack)

--- a/man/edit-cell-value.md
+++ b/man/edit-cell-value.md
@@ -10,6 +10,23 @@ Supports,
 * Programmatic configuration of input character class constraints.
 * Invalid cells in editing support virtualization (being scrolled out, then back in)
 
+The component will dispatch the following events:
+
+* `change` when the value has been changed and passes validation.
+  The component will not change the value of the row itself -- you should do that yourself.
+  See on the example below.
+* `validationerror` when the attempted change did not passed the provided validation.
+* `editstart` when editing is started
+* `editend` when editing is finished, either by the commit of a new value or by cancelling the edit operation.
+
+The component can be configured with the following getter setters:
+
+* `validate`: a function that takes the editing row and the proposed value.
+  Should return nothing if the change is valid.
+  Otherwise, it should return the reason why the change was invalid.  Whatever is return will be passed to the validation error handler.
+* `editable`: Receives a "cell object"; should return true if the cell is editable.
+* `characterClass`: in the notation of Regular Expressions; if present will use this to restrict the characters that can be entered on the editor.
+
 The following example, available for running on the `/examples/edit-cells.html` file.
 Showcases the `edit-cell-value` configuration.
 
@@ -30,6 +47,8 @@ var table = grid.createGrid()
                 gridComponents.createEditCellValue()
                     .on('change', onUsernameChange)
                     .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                    .on('editstart', d => console.debug('edit start',  d))
+                    .on('editend', d => console.debug('edit end', d))
                     .characterClass('A-Za-z0-5')
                     .validate(validateUserName)
                     .editable(isNotZack)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid-components",
-  "version": "0.5.0",
+  "version": "0.6.0-editstart-editend.1",
   "description": "Components for the Zambezi Grids",
   "keywords": [
     "d3",

--- a/src/edit-cell.js
+++ b/src/edit-cell.js
@@ -1,4 +1,5 @@
 import { appendIfMissing, rebind } from '@zambezi/d3-utils'
+import { debounce, compose } from 'underscore'
 import { dispatch as createDispatch } from 'd3-dispatch'
 import { select, event } from 'd3-selection'
 import { unwrap } from '@zambezi/grid'
@@ -10,7 +11,7 @@ const append = appendIfMissing('span.edit-cell-input')
 export function createEditCell() {
 
   const rowToTemp = new WeakMap()
-      , dispatch = createDispatch('change', 'validationerror')
+      , dispatch = createDispatch('change', 'validationerror', 'editstart', 'editend')
       , api = rebind().from(dispatch, 'on')
 
   let gesture = 'dblclick'
@@ -34,6 +35,7 @@ export function createEditCell() {
           , row = unwrap(d.row)
           , temp = rowToTemp.get(row)
           , cell = select(this)
+          , notifyEditEndDebounced = debounce(notifyEditEnd, 0)
 
       if (isEditable && temp && temp.value !== undefined) {
 
@@ -43,8 +45,9 @@ export function createEditCell() {
         component
             .on('partialedit.cache', cacheTemp)
             .on('cancel.clear', removeTmp)
+            .on('cancel.notify', notifyEditEndDebounced)
             .on('cancel.redraw', () => select(this).dispatch('redraw', { bubbles: true }) )
-            .on('commit.clear', onCommit)
+            .on('commit.process', compose(notifyEditEndDebounced, validateChange))
             .on('commit.redraw', () => select(this).dispatch('redraw', { bubbles: true }) )
 
         cell.select(append)
@@ -53,7 +56,6 @@ export function createEditCell() {
       } else {
         cell.classed('is-editing', false).select('.edit-cell-input').remove()
       }
-
     }
 
     function startEdit(d, i) {
@@ -63,6 +65,9 @@ export function createEditCell() {
       if (isAlreadyEditing) return
 
       rowToTemp.set(unwrappedRow, {value: d.value, valid: true})
+
+      dispatch.call('editstart', this, unwrappedRow)
+
       select(this)
           .classed('is-editing', true)
           .dispatch('redraw', { bubbles: true })
@@ -76,15 +81,24 @@ export function createEditCell() {
       rowToTemp.delete(unwrap(d.row))
     }
 
-    function onCommit(d) {
-      const reason = validate.call(this, d, this.value)
+    function notifyEditEnd(d) {
+      if (!d) return
+      dispatch.call('editend', this, unwrap(d))
+    }
 
-      if (!reason)  {
+    function validateChange(d) {
+      const unwrappedRow = unwrap(d.row)
+          , reason = validate.call(this, d, this.value)
+          , isValid = !reason
+
+      if (isValid)  {
         removeTmp(d)
-        dispatch.call('change', this, unwrap(d.row), this.value)
+        dispatch.call('change', this, unwrappedRow, this.value)
+        return d
       } else {
-        rowToTemp.set(unwrap(d.row), { value: this.value, valid: false })
+        rowToTemp.set(unwrappedRow, { value: this.value, valid: false })
         dispatch.call('validationerror', this, reason)
+        return null
       }
     }
   }

--- a/src/edit-cell.js
+++ b/src/edit-cell.js
@@ -30,7 +30,6 @@ export function createEditCell() {
     target.each(draw)
 
     function draw(d, i) {
-
       const isEditable = editable.call(this, d, i)
           , row = unwrap(d.row)
           , temp = rowToTemp.get(row)


### PR DESCRIPTION
## Motivation and Context

It's useful to know when a cell action starts and ends -- one might, for example, suspend streaming prices while the grid is in edit mode.
This change provides a pair of edit start/end events to support this.

## How Was This Tested?

On a rig from a pre-release version, `0.6.0-editstart-editend.1`  published to NPM.
http://bl.ocks.org/gabrielmontagne/f83bfda1e29501cbcd3a7ed820e18a2a



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
