### PR TITLE
WIP -- Fix esc and double commits

### DIFF
--- a/examples/edit-cells-lock-on-edit.html
+++ b/examples/edit-cells-lock-on-edit.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+<h1>Edit cell values -- cancel while editing</h1>
+
+<p>
+  On this example, we use cell editing start / end to stop and restart fake "updates".
+</p>
+
+<h2>Configuration</h2>
+
+<p>
+  Some extra example configuration has been added:
+</p>
+
+<dl>
+  <dt>Validation</dt>
+  <dd>Username cannot be empty</dd>
+  <dd>Username cannot use only one letter </dd>
+  <dt>Character class for input</dt><dd>Only uppercase and lower case ASCII characters and numbers between 0 and 5 can used to input usernames.</dd>
+  <dt>Non editable cells</dt><dd>Cells for rows in which the username begins with "Zac" cannot be edited</dd>
+  <dt>Processing</dt><dd>Client can decide how to consolidate the change; in this case, it is turned into upper case</dd>
+</dl>
+
+<div class="grid-target"></div>
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/grid/dist/grid.js"></script>
+<script src="../dist/grid-components.js"></script>
+<script>
+
+  let locked = false
+  const table = grid.createGrid()
+            .columns(
+              [
+                { key: 'name', locked: 'left', width: 200 }
+              , {
+                  key: 'username'
+                , components: [
+                    gridComponents.createEditCellValue()
+                        .on('change', onUsernameChange)
+                        .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                        .on('editstart.clear', () => console.clear())
+                        .on('editstart.lock', () => locked = true)
+                        .on('editstart.debug', d => console.debug('EDIT START',  d))
+                        .on('editend.unlock', () => locked = false)
+                        .on('editend.redraw', () => {draw(); draw(); draw()})
+                        .on('editend.debug', d => console.debug('EDIT END', d))
+                        .characterClass('A-Za-z0-5')
+                        .validate(validateUserName)
+                        .editable(isNotZack)
+
+                  , grid.updateTextIfChanged
+                  ]
+                }
+              , { key: 'email', sortDescending: true }
+              , { key: 'phone' }
+              ]
+            )
+            .on('draw', () => console.log('grid drawn'))
+
+      , i = setInterval(draw, 1000)
+
+  draw()
+
+  function draw() {
+
+    if (locked) return
+
+    console.log('draw!')
+
+    const rows = _.range(1, 10).map(faker.Helpers.createCard)
+    d3.select('.grid-target')
+        .style('height', '500px')
+        .datum(rows)
+        .call(table)
+  }
+
+  function onUsernameChange(row, value) {
+    console.warn('CHANGE!')
+    row.username = value.toUpperCase()
+  }
+
+  function validateUserName(row, value) {
+    if (!value) return 'Username cannot be empty'
+    if (!value.split('').some(isDifferentCharacter())) return 'Cannot all be the same character'
+  }
+
+  function isDifferentCharacter() {
+    let found
+    return function check(ch) {
+      if (found && !~found.indexOf(ch)) return true
+      found = ch
+      return false
+    }
+  }
+
+  function isNotZack(cell) {
+    return cell.row.username.indexOf('Zac') !== 0
+  }
+
+</script>
+</body>

--- a/examples/edit-cells.html
+++ b/examples/edit-cells.html
@@ -35,8 +35,8 @@
 <script src="../dist/grid-components.js"></script>
 <script>
 
-  let locked = false
-  const table = grid.createGrid()
+  const rows = _.range(1, 10).map(faker.Helpers.createCard)
+      , table = grid.createGrid()
             .columns(
               [
                 { key: 'name', locked: 'left', width: 200 }
@@ -46,12 +46,6 @@
                     gridComponents.createEditCellValue()
                         .on('change', onUsernameChange)
                         .on('validationerror', console.error.bind(console, 'VALIDATION'))
-                        .on('editstart.clear', () => console.clear())
-                        .on('editstart.lock', () => locked = true)
-                        .on('editstart.debug', d => console.debug('EDIT START',  d))
-                        .on('editend.unlock', () => locked = false)
-                        .on('editend.redraw', () => {draw(); draw(); draw()})
-                        .on('editend.debug', d => console.debug('EDIT END', d))
                         .characterClass('A-Za-z0-5')
                         .validate(validateUserName)
                         .editable(isNotZack)
@@ -63,27 +57,13 @@
               , { key: 'phone' }
               ]
             )
-            .on('draw', () => console.log('grid drawn'))
 
-      , i = setInterval(draw, 1000)
-
-  draw()
-
-  function draw() {
-
-    if (locked) return
-
-    console.log('draw!')
-
-    const rows = _.range(1, 10).map(faker.Helpers.createCard)
-    d3.select('.grid-target')
-        .style('height', '500px')
-        .datum(rows)
-        .call(table)
-  }
+  d3.select('.grid-target')
+      .style('height', '500px')
+      .datum(rows)
+      .call(table)
 
   function onUsernameChange(row, value) {
-    console.warn('CHANGE!')
     row.username = value.toUpperCase()
   }
 

--- a/examples/edit-cells.html
+++ b/examples/edit-cells.html
@@ -35,37 +35,55 @@
 <script src="../dist/grid-components.js"></script>
 <script>
 
-  var table = grid.createGrid()
-          .columns(
-            [
-              { key: 'name', locked: 'left', width: 200 }
-            , {
-                key: 'username'
-              , components: [
-                  gridComponents.createEditCellValue()
-                      .on('change', onUsernameChange)
-                      .on('validationerror', console.error.bind(console, 'VALIDATION'))
-                      .on('editstart', d => console.debug('edit start',  d))
-                      .on('editend', d => console.debug('edit end', d))
-                      .characterClass('A-Za-z0-5')
-                      .validate(validateUserName)
-                      .editable(isNotZack)
+  let locked = false
+  const table = grid.createGrid()
+            .columns(
+              [
+                { key: 'name', locked: 'left', width: 200 }
+              , {
+                  key: 'username'
+                , components: [
+                    gridComponents.createEditCellValue()
+                        .on('change', onUsernameChange)
+                        .on('validationerror', console.error.bind(console, 'VALIDATION'))
+                        .on('editstart.clear', () => console.clear())
+                        .on('editstart.lock', () => locked = true)
+                        .on('editstart.debug', d => console.debug('EDIT START',  d))
+                        .on('editend.unlock', () => locked = false)
+                        .on('editend.redraw', () => {draw(); draw(); draw()})
+                        .on('editend.debug', d => console.debug('EDIT END', d))
+                        .characterClass('A-Za-z0-5')
+                        .validate(validateUserName)
+                        .editable(isNotZack)
 
-                , grid.updateTextIfChanged
-                ]
-              }
-            , { key: 'email', sortDescending: true }
-            , { key: 'phone' }
-            ]
-          )
-    , rows = _.range(1, 2000).map(faker.Helpers.createCard)
+                  , grid.updateTextIfChanged
+                  ]
+                }
+              , { key: 'email', sortDescending: true }
+              , { key: 'phone' }
+              ]
+            )
+            .on('draw', () => console.log('grid drawn'))
 
-  d3.select('.grid-target')
-      .style('height', '500px')
-      .datum(rows)
-      .call(table)
+      , i = setInterval(draw, 1000)
+
+  draw()
+
+  function draw() {
+
+    if (locked) return
+
+    console.log('draw!')
+
+    const rows = _.range(1, 10).map(faker.Helpers.createCard)
+    d3.select('.grid-target')
+        .style('height', '500px')
+        .datum(rows)
+        .call(table)
+  }
 
   function onUsernameChange(row, value) {
+    console.warn('CHANGE!')
     row.username = value.toUpperCase()
   }
 

--- a/src/edit-cell-value.js
+++ b/src/edit-cell-value.js
@@ -35,6 +35,8 @@ function createEditValue() {
   return api(editValue)
 
   function editValueEach(d, i) {
+    let isCancelled
+      , isCommited
 
     const input = select(this)
             .select(appendInput)
@@ -48,14 +50,26 @@ function createEditValue() {
                     null
                   , keyDownHandlers.concat(
                       [
-                        keyCodeHandler((d) => dispatch.call('commit', input.node(), d), 13)
-                      , keyCodeHandler((d) => dispatch.call('cancel', input.node(), d), 27)
+                        keyCodeHandler(onCancel, 27)
+                      , keyCodeHandler(onCommit, 13)
                       ]
                     )
                 )
               )
-              .on('blur.process', (d) => dispatch.call('commit', input.node(), d))
+              .on('blur.process', onCommit)
 
     if (d.isValidInput) input.node().focus()
+
+    function onCommit(d) {
+      if (isCancelled) return
+      if (isCommited) return
+      isCommited = true
+      dispatch.call('commit', input.node(), d)
+    }
+
+    function onCancel(d) {
+      isCancelled = true
+      dispatch.call('cancel', input.node(), d)
+    }
   }
 }

--- a/src/edit-cell.js
+++ b/src/edit-cell.js
@@ -1,5 +1,5 @@
 import { appendIfMissing, rebind } from '@zambezi/d3-utils'
-import { debounce, compose } from 'underscore'
+import { compose } from 'underscore'
 import { dispatch as createDispatch } from 'd3-dispatch'
 import { select, event } from 'd3-selection'
 import { unwrap } from '@zambezi/grid'
@@ -34,7 +34,6 @@ export function createEditCell() {
           , row = unwrap(d.row)
           , temp = rowToTemp.get(row)
           , cell = select(this)
-          , notifyEditEndDebounced = debounce(notifyEditEnd, 0)
 
       if (isEditable && temp && temp.value !== undefined) {
 
@@ -44,9 +43,9 @@ export function createEditCell() {
         component
             .on('partialedit.cache', cacheTemp)
             .on('cancel.clear', removeTmp)
-            .on('cancel.notify', notifyEditEndDebounced)
+            .on('cancel.notify', notifyEditEnd)
             .on('cancel.redraw', () => select(this).dispatch('redraw', { bubbles: true }) )
-            .on('commit.process', compose(notifyEditEndDebounced, validateChange))
+            .on('commit.process', compose(notifyEditEnd, validateChange))
             .on('commit.redraw', () => select(this).dispatch('redraw', { bubbles: true }) )
 
         cell.select(append)


### PR DESCRIPTION
## Description

Fix cell editor flakyness

## Motivation and Context

The current cell value editor is a bit flaky -- might dispatch `commit` right after `cancel` or might dispatch a couple of `commit` events when only one was expected.

This branch / PR attempts to make it more robust.

## How Was This Tested?

A version of the edit cell block has been updated to use a pre-release version with this fix:
http://bl.ocks.org/gabrielmontagne/a6aaeeef596ad1473532318d153f0836

Also, an extra rig which exposes the problems has been added,  `examples/edit-cells-lock-on-edit.html`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
