### PR TITLE
Groups gather work

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 - Grid components
   - [Cell selection](man/cell-selection.md)
   - [Run header components](man/run-header-components.md)
+  - [Gather rows](man/gather-rows.md)
 
 - Column specific components
   - [Edit cell value](man/edit-cell-value.md)

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -19,20 +19,25 @@
             .groups(
               [
                 {
-                  label: 'Usernames with dots',
-                  predicate:  row => row.username.indexOf('.') >= 0
+                  label: 'Usernames with dots'
+                , predicate:  row => row.username.indexOf('.') >= 0
+                , children: []
                 },
 
                 {
-                  label: 'Usernames with underscores',
-                  predicate:  row => row.username.indexOf('_') >= 0
+                  label: 'Usernames with underscores'
+                , predicate:  row => row.username.indexOf('_') >= 0
+                , children: []
                 },
                 {
                   label: 'Something that does not match on this dataset'
                 , predicate: () => false
+                , children: []
                 },
                 {
                   label: 'Other usernames'
+                , predicate: () => true
+                , children: []
                 }
               ]
             )

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -38,16 +38,7 @@
       , table = grid.createGrid()
             .columns(
               [
-                {
-                  components: [ grid.createNestedRowExpanders() ]
-                , key: 'label'
-                , label: 'expanders'
-                , width: 100
-                , resizable: false
-                , draggable: false
-                }
-
-              , { key: 'name', width: 200 }
+                { key: 'name', width: 200 }
               , { key: 'username' }
               , { key: 'email' }
               , { key: 'phone' }

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+
+<div class="grid-target"></div>
+
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/grid/dist/grid.js"></script>
+<script src="../dist/grid-components.js"></script>
+<script>
+
+  var rows = _.range(1, 50).map(faker.Helpers.createCard)
+    , gatherRows = gridComponents.createGatherRows()
+    , table = grid.createGrid()
+          .columns(
+            [
+              { key: 'name', width: 200 }
+            , { key: 'username' }
+            , { key: 'email' }
+            , { key: 'phone' }
+            ]
+          )
+          .usePre(gatherRows)
+
+    , target = d3.select('.grid-target')
+          .style('height', '300px')
+          .datum(rows)
+          .call(table)
+</script>
+</body>

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -21,23 +21,17 @@
                 {
                   label: 'Usernames with dots'
                 , predicate:  row => row.username.indexOf('.') >= 0
-                , children: []
                 },
-
                 {
                   label: 'Usernames with underscores'
                 , predicate:  row => row.username.indexOf('_') >= 0
-                , children: []
                 },
                 {
                   label: 'Something that does not match on this dataset'
                 , predicate: () => false
-                , children: []
                 },
                 {
                   label: 'Other usernames'
-                , predicate: () => true
-                , children: []
                 }
               ]
             )

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -14,51 +14,51 @@
 <script src="../dist/grid-components.js"></script>
 <script>
 
-  var rows = _.range(1, 50).map(faker.Helpers.createCard)
-    , gatherRows = gridComponents.createGatherRows()
-          .groups(
-            [
-              {
-                label: 'Usernames with dots',
-                predicate:  row => row.username.indexOf('.') >= 0
-              },
+  const rows = _.range(1, 50).map(faker.Helpers.createCard)
+      , gatherRows = gridComponents.createGatherRows()
+            .groups(
+              [
+                {
+                  label: 'Usernames with dots',
+                  predicate:  row => row.username.indexOf('.') >= 0
+                },
 
-              {
-                label: 'Usernames with underscores',
-                predicate:  row => row.username.indexOf('_') >= 0
-              },
-              {
-                label: 'Something that does not match on this dataset'
-              , predicate: () => false
-              },
-              {
-                label: 'Other usernames'
-              }
-            ]
-          )
-    , table = grid.createGrid()
-          .columns(
-            [
-              {
-                components: [ grid.createNestedRowExpanders() ]
-              , key: 'label'
-              , label: 'expanders'
-              , width: 100
-              , resizable: false
-              , draggable: false
-              }
+                {
+                  label: 'Usernames with underscores',
+                  predicate:  row => row.username.indexOf('_') >= 0
+                },
+                {
+                  label: 'Something that does not match on this dataset'
+                , predicate: () => false
+                },
+                {
+                  label: 'Other usernames'
+                }
+              ]
+            )
+      , table = grid.createGrid()
+            .columns(
+              [
+                {
+                  components: [ grid.createNestedRowExpanders() ]
+                , key: 'label'
+                , label: 'expanders'
+                , width: 100
+                , resizable: false
+                , draggable: false
+                }
 
-            , { key: 'name', width: 200 }
-            , { key: 'username' }
-            , { key: 'email' }
-            , { key: 'phone' }
-            ]
-          )
-          .usePre(gatherRows)
+              , { key: 'name', width: 200 }
+              , { key: 'username' }
+              , { key: 'email' }
+              , { key: 'phone' }
+              ]
+            )
+            .usePre(gatherRows)
 
-    , target = d3.select('.grid-target')
-          .style('height', '800px')
-          .datum(rows)
-          .call(table)
+      , target = d3.select('.grid-target')
+            .style('height', '800px')
+            .datum(rows)
+            .call(table)
 </script>
 </body>

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -35,7 +35,6 @@
                 label: 'Other usernames'
               }
             ]
-
           )
     , table = grid.createGrid()
           .columns(

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -16,10 +16,40 @@
 
   var rows = _.range(1, 50).map(faker.Helpers.createCard)
     , gatherRows = gridComponents.createGatherRows()
+          .groups(
+            [
+              {
+                label: 'Usernames with dots',
+                predicate:  row => row.username.indexOf('.') >= 0
+              },
+
+              {
+                label: 'Usernames with underscores',
+                predicate:  row => row.username.indexOf('_') >= 0
+              },
+              {
+                label: 'Something that does not match on this dataset'
+              , predicate: () => false
+              },
+              {
+                label: 'Other usernames'
+              }
+            ]
+
+          )
     , table = grid.createGrid()
           .columns(
             [
-              { key: 'name', width: 200 }
+              {
+                components: [ grid.createNestedRowExpanders() ]
+              , key: 'label'
+              , label: 'expanders'
+              , width: 100
+              , resizable: false
+              , draggable: false
+              }
+
+            , { key: 'name', width: 200 }
             , { key: 'username' }
             , { key: 'email' }
             , { key: 'phone' }
@@ -28,7 +58,7 @@
           .usePre(gatherRows)
 
     , target = d3.select('.grid-target')
-          .style('height', '300px')
+          .style('height', '800px')
           .datum(rows)
           .call(table)
 </script>

--- a/man/gather-rows.md
+++ b/man/gather-rows.md
@@ -1,0 +1,60 @@
+## gather rows
+
+Row grouping can be extracted from the rows themselves by using [row grouping](https://github.com/zambezi/grid/blob/master/man/grouped-rows.md) on the Zambezi grid directly.
+But sometimes we might have the groups first, and we would like to gather rows around them, and have them be active even if no rows match.
+
+The `gatherRows` component is designed for this:  you pre-define the groups, and create a predicate for each that will be tested for each row to determine on which group it belongs.
+Groups are tested in order, and the first one that matches will be used.
+
+To use, configure the component with _group_ objects, that define the label and the predicate.
+These groups will become the rows under which the data rows will be nested.
+The grid will also render the summary rows with `+-` expanders.
+
+Then tell the grid to use the component by passing it to the grid's `usePre` method.
+
+
+```
+const gatherRows = createGatherRows()
+          .groups(
+            [
+              {
+                label: 'Usernames with dots'
+              , predicate:  row => row.username.indexOf('.') >= 0
+              }
+            , {
+                label: 'Usernames with underscores'
+              , predicate:  row => row.username.indexOf('_') >= 0
+              }
+            , {
+                label: 'Something that does not match on this dataset'
+              , predicate: () => false
+              }
+            , {
+                label: 'Other usernames'
+              }
+            ]
+          )
+    , table = grid.createGrid()
+          .columns(
+            [
+              { key: 'name', width: 200 }
+            , { key: 'username' }
+            , { key: 'email' }
+            , { key: 'phone' }
+            ]
+          )
+          .usePre(gatherRows)
+
+d3.select('.grid-target')
+      .style('height', '800px')
+      .datum(rows)
+      .call(table)
+
+```
+
+### further configuration
+
+Additional configuration is available for this component:
+
+* Use `defaultExpanded` if you want grouped rows to be expanded by default.
+* Use `defaultPredicate` to configure which predicate to use when missing from the group configuration.  By default, a catch all `() => true` is provided, so all rows that have not been set to a previous group will be caught. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid-components",
-  "version": "0.6.1-fix-esc-and-double-commits.1",
+  "version": "0.7.0-group-gather-work.1",
   "description": "Components for the Zambezi Grids",
   "keywords": [
     "d3",

--- a/src/gather-rows.css
+++ b/src/gather-rows.css
@@ -13,9 +13,9 @@
 
 .zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label {
   position: absolute;
-  left: 8px;
   top: 2px;
 }
+
 .zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label:before {
 
   font-size: 14px;

--- a/src/gather-rows.css
+++ b/src/gather-rows.css
@@ -16,22 +16,22 @@
   top: 2px;
 }
 
-.zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label:before {
+.zambezi-grid-row.is-gather-group-row .zambezi-group-toggle:before {
 
   font-size: 14px;
+  font-style: normal;
   font-family: monospace;
   white-space: pre;
   color: #555;
   content: ' ';
   margin: 4px;
+
 }
 
-.zambezi-grid-row.is-gather-group-row.is-expand .zambezi-gather-group-label:before {
+.zambezi-grid-row.is-gather-group-row.is-expand .zambezi-group-toggle:before {
   content: '➖';
 }
 
-.zambezi-grid-row.is-gather-group-row.is-collapse .zambezi-gather-group-label:before {
+.zambezi-grid-row.is-gather-group-row.is-collapse .zambezi-group-toggle:before {
   content: '➕';
 }
-
-

--- a/src/gather-rows.css
+++ b/src/gather-rows.css
@@ -1,0 +1,13 @@
+.zambezi-grid-row.is-gather-group-row {
+  background-color: #CCC;
+}
+
+.zambezi-grid-row.is-gather-group-row .zambezi-grid-cell{
+  border-right: none;
+}
+
+.zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label {
+  position: absolute;
+  left: 8px;
+  top: 2px;
+}

--- a/src/gather-rows.css
+++ b/src/gather-rows.css
@@ -1,8 +1,13 @@
 .zambezi-grid-row.is-gather-group-row {
-  background-color: #CCC;
+  background-color: #DDD;
 }
 
-.zambezi-grid-row.is-gather-group-row .zambezi-grid-cell{
+.zambezi-grid-row.is-gather-group-row.has-children {
+  background-color: #CACACA;
+  cursor: pointer;
+}
+
+.zambezi-grid-row.is-gather-group-row .zambezi-grid-cell {
   border-right: none;
 }
 
@@ -11,3 +16,22 @@
   left: 8px;
   top: 2px;
 }
+.zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label:before {
+
+  font-size: 14px;
+  font-family: monospace;
+  white-space: pre;
+  color: #555;
+  content: ' ';
+  margin: 4px;
+}
+
+.zambezi-grid-row.is-gather-group-row.is-expand .zambezi-gather-group-label:before {
+  content: '➖';
+}
+
+.zambezi-grid-row.is-gather-group-row.is-collapse .zambezi-gather-group-label:before {
+  content: '➕';
+}
+
+

--- a/src/gather-rows.js
+++ b/src/gather-rows.js
@@ -1,0 +1,14 @@
+export function createGatherRows() {
+  function gatherRows(s) {
+    s.each(gatherRowsEach)
+  }
+
+  return gatherRows
+
+  function gatherRowsEach(d, i) {
+    console.log('gather rows component running on', this, d)
+  }
+}
+
+
+

--- a/src/gather-rows.js
+++ b/src/gather-rows.js
@@ -7,6 +7,8 @@ import './gather-rows.css'
 
 const rowLabelClass = 'zambezi-gather-group-label'
     , rowLabel = appendIfMissing(`span.${rowLabelClass}`)
+    , rowIcon = appendIfMissing('i.zambezi-group-toggle')
+    , rowTitle = appendIfMissing('span.zambezi-group-title')
 
 export function createGatherRows() {
   let groups = []
@@ -70,6 +72,10 @@ export function createGatherRows() {
         , target = select(this)
         , classed = target.classed('is-gather-group-row')
 
+    let labelTarget
+      , titleTarget
+      , iconTarget
+
     target.classed('is-gather-group-row', isGroupRow)
         .classed('has-children', isGroupRow && children && children.length)
         .classed('is-expand', isGroupRow && children.length && expanded )
@@ -78,7 +84,9 @@ export function createGatherRows() {
     if (!isGroupRow || !renderLabel)  {
       target.select(`.${rowLabelClass}`).remove()
     } else { 
-      target.select(rowLabel).text(label)
+      labelTarget = target.select(rowLabel)
+      iconTarget = labelTarget.select(rowIcon)
+      titleTarget = labelTarget.select(rowTitle).text(label)
     }
 
     target.on('click.gather-rows', isGroupRow ? onRowClick : null)

--- a/src/gather-rows.js
+++ b/src/gather-rows.js
@@ -1,8 +1,6 @@
 import { isUndefined, find } from 'underscore'
 
-
 export function createGatherRows() {
-
   let groups = []
     , cache
     , expandedRowByLabel = {}

--- a/src/gather-rows.js
+++ b/src/gather-rows.js
@@ -1,14 +1,42 @@
+import { clone, find } from 'underscore'
+
+const defaultPredicate = () => true
+
 export function createGatherRows() {
+
+  let groups = []
+    , cache
+
   function gatherRows(s) {
     s.each(gatherRowsEach)
+        .on('data-dirty.gather-rows', () => cache = null)
+  }
+
+  gatherRows.groups = function(value) {
+    if (!arguments.length) return groups
+    groups = value
+    return gatherRows
   }
 
   return gatherRows
 
   function gatherRowsEach(d, i) {
-    console.log('gather rows component running on', this, d)
+    if (!cache) { 
+      cache = d.rows.reduce(
+        gather, groups.map(
+          d => Object.assign({ children: [], predicate: defaultPredicate }, d)
+        )
+      )
+    }
+    d.rows = cache
+    console.log(cache)
+  }
+
+  function gather(targets, row) {
+    const target = find(targets, t => t.predicate(row))
+    if (!target) return targets
+    target.children.push(row)
+    target.expanded = true
+    return targets
   }
 }
-
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,4 @@ export { createEditCellValue } from './edit-cell-value'
 export { createGatherRows } from './gather-rows'
 export { createPopover } from './popover'
 export { createRunHeaderComponents } from './run-header-components'
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export { createCellSelection } from './cell-selection'
 export { createEditCell } from './edit-cell'
 export { createEditCellValue } from './edit-cell-value'
+export { createGatherRows } from './gather-rows'
 export { createPopover } from './popover'
 export { createRunHeaderComponents } from './run-header-components'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

From the proposed docs:

> Row grouping can be extracted from the rows themselves by using [row grouping](https://github.com/zambezi/grid/blob/master/man/grouped-rows.md) on the Zambezi grid directly.
> But sometimes we might have the groups first, and we would like to gather rows around them, and have them be active even if no rows match.
>
> The `gatherRows` component is designed for this:  you pre-define the groups, and create a predicate for each that will be tested for each row to determine on which group it belongs.
> Groups are tested in order, and the first one that matches will be used.

https://github.com/zambezi/grid-components/blob/3c96311e465aac1e0dc3e64f926183ad328a02e4/man/gather-rows.md


## Motivation and Context

At work I've been asked for 
* a way to define groups even when no rows belong to the group
* an easier way to label and configure grouped rows.

This PR attempts to address both.



## How Was This Tested?
<!--- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Offline on special rigs, on a provided exmple (in the `examples` folder)  and on this public block, set up with a pre-release version of the component,

https://bl.ocks.org/gabrielmontagne/b8e3ec92c42f3b17c3c2cc59f6752878


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
