### PR TITLE
Constrain gather rows toggle area

### DIFF
--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -41,7 +41,10 @@
                 { key: 'name', width: 200 }
               , { key: 'username' }
               , { key: 'email' }
-              , { key: 'phone' }
+              , { 
+                  key: 'phone'
+                , components: [ callMeAll, grid.updateTextIfChanged ]
+                }
               , {
                   label: 'Price'
                 , format: gridComponents.nestedRowFormat(
@@ -66,6 +69,20 @@
   function addPrice(r) {
     r.price = Math.round(price() / 10) * 10
     return r
+  }
+
+  function callMeAll(d) {
+    const target = d3.select(this)
+    if (!d.row.isGroupRow) {
+      target.select('button').remove()
+    } else {
+      target.select(d3Utils.appendIfMissing('button'))
+          .on(
+            'click.debug', 
+            d => console.log('%c grouped rows component', 'background: #222; color: #bada55')
+          )
+          .text(_.uniqueId('ran_'))
+    }
   }
 
 </script>

--- a/examples/gather-rows.html
+++ b/examples/gather-rows.html
@@ -79,7 +79,7 @@
       target.select(d3Utils.appendIfMissing('button'))
           .on(
             'click.debug', 
-            d => console.log('%c grouped rows component', 'background: #222; color: #bada55')
+            d => console.log('grouped rows component', d)
           )
           .text(_.uniqueId('ran_'))
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid-components",
-  "version": "0.11.0",
+  "version": "0.12.0-constrain-gather-rows-toggle-area.1",
   "description": "Components for the Zambezi Grids",
   "keywords": [
     "d3",

--- a/src/gather-rows.css
+++ b/src/gather-rows.css
@@ -4,7 +4,6 @@
 
 .zambezi-grid-row.is-gather-group-row.has-children {
   background-color: #CACACA;
-  cursor: pointer;
 }
 
 .zambezi-grid-row.is-gather-group-row .zambezi-grid-cell {
@@ -14,6 +13,11 @@
 .zambezi-grid-row.is-gather-group-row .zambezi-gather-group-label {
   position: absolute;
   top: 2px;
+  z-index: 1;
+}
+
+.zambezi-grid-row.is-gather-group-row.has-children .zambezi-gather-group-label {
+  cursor: pointer;
 }
 
 .zambezi-grid-row.is-gather-group-row .zambezi-group-toggle:before {

--- a/src/gather-rows.js
+++ b/src/gather-rows.js
@@ -79,13 +79,13 @@ export function createGatherRows () {
       target.select(`.${rowLabelClass}`).remove()
     } else {
       labelTarget = target.select(rowLabel)
+          .on('click.gather-rows', toggleRowExpansion)
+
       labelTarget.select(rowIcon)
       labelTarget.select(rowTitle).text(label)
     }
 
-    target.on('click.gather-rows', isGroupRow ? onRowClick : null)
-
-    function onRowClick ({ row }) {
+    function toggleRowExpansion ({ row }) {
       const unwrapped = unwrap(row)
       unwrapped.expanded = !unwrapped.expanded
       event.stopImmediatePropagation()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. Screenshots (where appropriate) more than welcome! -->

The `gather-rows` component currently toggles its expanded state from all the row.
With this PR, the toggle area (with appropriate cursor, etc) is constrained only to sign + label for gather rows with children.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->

The original motivation was an interactivity conflict with nested components.
But thinking about a bit further, this interaction seems cleaner and less suprising.

## How Was This Tested?
<!--- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

In the provided `gather-rows.html` example, as well as on the public block, 
https://bl.ocks.org/gabrielmontagne/b8e3ec92c42f3b17c3c2cc59f6752878/b721086753d0ee904c1ac576f2c58386519337f5
running from a prerelease version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
