### PR TITLE
Fix active cell lost on new logical rows

### DIFF
--- a/src/cell-selection.js
+++ b/src/cell-selection.js
@@ -117,7 +117,7 @@ export function createCellSelection () {
   function cellSelectionEach (bundle) {
     const target = select(this)
             .on('data-dirty.cell-selection', () => (rowUpdateNeeded = true))
-    const { columns, rows } = bundle
+    const { columns } = bundle
     const columnById = indexBy(columns, 'id')
     const newRowByOldRow = new Map()
 
@@ -169,13 +169,12 @@ export function createCellSelection () {
         if (newRow) acc.push({column, row: newRow})
         return acc
       }
-
     }
 
-    function findNewRowForOld(row) {
+    function findNewRowForOld (row) {
       const rowSeen = newRowByOldRow.has(row)
       let newRow = newRowByOldRow.get(row)
-      if (rowSeen && !newRow) return acc
+      if (rowSeen && !newRow) return null
       if (!newRow) {
         newRow = find(bundle, r => rowSelectionKey(r) === rowSelectionKey(row))
         newRowByOldRow.set(row, newRow)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes active cell selection getting lost on data refresh

## Motivation and Context

In the next incarnation of the gird we should use [Immutable](https://facebook.github.io/immutable-js/) or similar.
But, for now, we're caught in the eternal death/rebirth cycles of bugs related to comparing references.

This PR tries to answer the question addresses the question: how does the cell selection component knows that this active cell points to a row that is now, actually, that one after a data refresh.

As usual, we use _row key_ functions that the user can provide.
On this component, this was called `rowSelectionKey`.

## How Was This Tested?
<!--- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

On the embedded `examples/keyboard-cell-selection.html`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
